### PR TITLE
Handle methods=null when generating service markdown

### DIFF
--- a/src/scala/io/bazeltools/proto3docgen/repr/Service.scala
+++ b/src/scala/io/bazeltools/proto3docgen/repr/Service.scala
@@ -10,7 +10,7 @@ case class Service(
   longName: String,
   fullName: String,
   description: String,
-  methods: List[Method]
+  methods: Option[List[Method]],
 )
 
 object Service {
@@ -25,7 +25,7 @@ object Service {
         .withInnerSection {
           import Method._
           Sectionable
-            .toSection(s.methods)
+            .toSection(s.methods.getOrElse(List.empty))
             .withName("Methods")
         }
   }

--- a/src/scala/io/bazeltools/proto3docgen/repr/Service.scala
+++ b/src/scala/io/bazeltools/proto3docgen/repr/Service.scala
@@ -10,7 +10,7 @@ case class Service(
   longName: String,
   fullName: String,
   description: String,
-  methods: Option[List[Method]],
+  methods: Option[List[Method]], // We will handle an empty list, circe however will complain if its null
 )
 
 object Service {

--- a/src/scala/io/bazeltools/proto3docgen/repr/Service.scala
+++ b/src/scala/io/bazeltools/proto3docgen/repr/Service.scala
@@ -25,7 +25,7 @@ object Service {
         .withInnerSection {
           import Method._
           Sectionable
-            .toSection(s.methods.getOrElse(List.empty))
+            .toSection(s.methods.getOrElse(Nil))
             .withName("Methods")
         }
   }


### PR DESCRIPTION
Our build is currently broken because a service definition we're now reading includes a `methods` field that's `null` in the JSON. We can handle this naively like so.